### PR TITLE
Ignore known issue with ISO 3166 supplements

### DIFF
--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -10,3 +10,6 @@ Best Practice Recommendation: In general, all observations should have a perform
 # No R5 DICOM package exists yet, but we have to depend on it for our DICOM supplement to resolve correctly - known issue, reported
 This IG is version 5.0.0, while the IG 'fhir.dicom' is from version 4.0.1 
 The ImplementationGuide is based on FHIR version 5.0.0 but package fhir.dicom#2025.2.20250411 is based on FHIR version 4.0.1. In general, this version mismatch should be avoided - some tools will try to make this work with variable degrees of success, but others will not even try 
+
+# IG publisher can't find supplements for ISO 3166 - reported
+The value provided ('UZ') was not found in the value set 'ISO 3166 2 character codes in Uzbek and Russian' (https://terminology.dhp.uz/ValueSet/iso-3166-2-uz-vs%


### PR DESCRIPTION
Ignore known issue with ISO 3166 supplements in the IG publisher - it has been reported.