### PR TITLE
Set IG license to CC BY-SA 4.0

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -13,7 +13,7 @@ version: 0.2.0
 fhirVersion: 5.0.0 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2025+
 releaseLabel: ci-build
-# license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
+license: CC-BY-SA-4.0
 jurisdiction: urn:iso:std:iso:3166#UZ "Uzbekistan"
 publisher:
   name: Uzinfocom LLC


### PR DESCRIPTION
Set IG license to CC BY-SA 4.0 - taken from https://github.com/uzinfocom-org/digital-health-ig