### PR TITLE
Fix canonical URL of benefits-cs

### DIFF
--- a/input/fsh/terminology/BenefitsCS.fsh
+++ b/input/fsh/terminology/BenefitsCS.fsh
@@ -2,6 +2,7 @@ CodeSystem: BenefitsCS
 Id: benefits-cs
 Title: "Types of benefits"
 Description: "Types of benefits in Uzbekistan"
+* ^url = "https://terminology.dhp.uz/CodeSystem/benefits-cs"
 * ^status = #active
 * ^content = #complete
 * ^caseSensitive = true


### PR DESCRIPTION
Fix canonical URL of benefits-cs to start with terminology.dhp.uz correctly.