### PR TITLE
Fix name of the Observation Interpretation codesystem

### DIFF
--- a/input/fsh/terminology/DataAbsentReasonCS.fsh
+++ b/input/fsh/terminology/DataAbsentReasonCS.fsh
@@ -1,7 +1,7 @@
 CodeSystem: DataAbsentReasonCS
 Id: data-absent-reason-cs
-Title: "UZCore data absent reason code sytem"
-Description: "Data absent reason suplement"
+Title: "Data absent reason"
+Description: "Data absent reason supplement with translations in Uzbek and Russian"
 * insert SupplementCodeSystemDraft(data-absent-reason-cs, $observation-dataAbsentReason, 1.0.0)
 
 * #unknown

--- a/input/fsh/terminology/ObservationInterpretationCS.fsh
+++ b/input/fsh/terminology/ObservationInterpretationCS.fsh
@@ -1,7 +1,7 @@
 CodeSystem: ObservationInterpretationCS
 Id: observation-interpretation-cs
-Title: "UZCore data absent reason code sytem"
-Description: "Data absent reason suplement"
+Title: "Observation interpretation"
+Description: "Observation interpretation supplement with translations in Uzbek and Russian"
 * insert SupplementCodeSystemDraft(observation-interpretation-cs, $observation-interpretation, 3.0.0)
 
 * #CAR

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -6,6 +6,8 @@ Patient disability status has been moved from the Patient resource (using a FHIR
 
 Underscores have been removed from NamingSystem identifiers.
 
+Name of the Observation Interpretation codesystem supplement has been fixed.
+
 ### Version 0.3.0
 
 UZ Core profiles for Encounter, EpisodeOfCare, and Observation have been added.


### PR DESCRIPTION
Fix name of the Observation Interpretation codesystem - it was copy/pasted